### PR TITLE
Refs [TASK][34562] Get data home page from api

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ android {
         targetSdkVersion 30
         versionCode 1
         versionName "1.0"
-
+        buildConfigField "String", "API_KEY", "\"${API_KEY}\""
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.sun.spoonacular">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/com/sun/spoonacular/MainActivity.kt
+++ b/app/src/main/java/com/sun/spoonacular/MainActivity.kt
@@ -5,9 +5,8 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.widget.Toast
-import com.sun.spoonacular.ui.base.MainFragment
 import com.sun.spoonacular.ui.splash.SplashFragment
-import com.sun.spoonacular.utils.addFragment
+import com.sun.spoonacular.utils.addFragmentNoStack
 
 class MainActivity : AppCompatActivity() {
 
@@ -16,7 +15,7 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-        addFragment(SplashFragment.newInstance(),R.id.mainContainer)
+        addFragmentNoStack(SplashFragment.newInstance(), R.id.mainContainer)
     }
 
     override fun onBackPressed() {

--- a/app/src/main/java/com/sun/spoonacular/data/model/Recipe.kt
+++ b/app/src/main/java/com/sun/spoonacular/data/model/Recipe.kt
@@ -1,0 +1,25 @@
+package com.sun.spoonacular.data.model
+
+import android.os.Parcelable
+import com.google.gson.annotations.Expose
+import com.google.gson.annotations.SerializedName
+import kotlinx.android.parcel.Parcelize
+
+@Parcelize
+data class Recipe(
+    @SerializedName("id")
+    @Expose
+    val id: Int?,
+    @SerializedName("title")
+    @Expose
+    val title: String?,
+    @SerializedName("readyInMinutes")
+    @Expose
+    val timeCook: String?,
+    @SerializedName("spoonacularScore")
+    @Expose
+    val score: Double?,
+    @SerializedName("image")
+    @Expose
+    val image: String?
+) : Parcelable

--- a/app/src/main/java/com/sun/spoonacular/data/model/RecipeResponse.kt
+++ b/app/src/main/java/com/sun/spoonacular/data/model/RecipeResponse.kt
@@ -1,0 +1,13 @@
+package com.sun.spoonacular.data.model
+
+import android.os.Parcelable
+import com.google.gson.annotations.Expose
+import com.google.gson.annotations.SerializedName
+import kotlinx.android.parcel.Parcelize
+
+@Parcelize
+data class RecipeResponse(
+    @SerializedName("recipes")
+    @Expose
+    val recipes: List<Recipe>
+) : Parcelable

--- a/app/src/main/java/com/sun/spoonacular/data/source/DataSource.kt
+++ b/app/src/main/java/com/sun/spoonacular/data/source/DataSource.kt
@@ -1,0 +1,11 @@
+package com.sun.spoonacular.data.source
+
+import com.sun.spoonacular.data.model.RecipeResponse
+import retrofit2.Response
+
+interface DataSource {
+
+    interface Remote {
+        suspend fun getRecipe(): Response<RecipeResponse>
+    }
+}

--- a/app/src/main/java/com/sun/spoonacular/data/source/Repository.kt
+++ b/app/src/main/java/com/sun/spoonacular/data/source/Repository.kt
@@ -1,0 +1,13 @@
+package com.sun.spoonacular.data.source
+
+import com.sun.spoonacular.data.source.remote.RemoteDataSource
+
+class Repository private constructor(private val remote: DataSource.Remote) {
+
+    suspend fun getRecipe() = remote.getRecipe()
+
+    companion object {
+        private var instance : Repository? = null
+        fun getInstance() = instance ?: Repository((RemoteDataSource.getInstance())).also { instance = it }
+    }
+}

--- a/app/src/main/java/com/sun/spoonacular/data/source/remote/RemoteDataSource.kt
+++ b/app/src/main/java/com/sun/spoonacular/data/source/remote/RemoteDataSource.kt
@@ -1,0 +1,18 @@
+package com.sun.spoonacular.data.source.remote
+
+import com.sun.spoonacular.data.model.RecipeResponse
+import com.sun.spoonacular.data.source.DataSource
+import com.sun.spoonacular.data.source.remote.api.ApiClient
+import retrofit2.Response
+
+class RemoteDataSource private constructor() : DataSource.Remote {
+
+    override suspend fun getRecipe(): Response<RecipeResponse> {
+        return ApiClient.apiService.getRecipe()
+    }
+
+    companion object {
+        private var instance: RemoteDataSource? = null
+        fun getInstance() = instance ?: RemoteDataSource().also { instance = it }
+    }
+}

--- a/app/src/main/java/com/sun/spoonacular/data/source/remote/api/ApiClient.kt
+++ b/app/src/main/java/com/sun/spoonacular/data/source/remote/api/ApiClient.kt
@@ -1,0 +1,33 @@
+package com.sun.spoonacular.data.source.remote.api
+
+import com.sun.spoonacular.utils.Constant
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
+
+object ApiClient {
+
+    private const val CONNECT_TIMEOUT = 60L
+    private const val READ_TIMEOUT = 30L
+
+    private fun callApi(): Retrofit {
+        val builder = OkHttpClient
+            .Builder()
+            .connectTimeout(CONNECT_TIMEOUT, TimeUnit.SECONDS)
+            .readTimeout(READ_TIMEOUT, TimeUnit.SECONDS)
+            .retryOnConnectionFailure(true)
+
+        builder.interceptors().add(AuthenticationInterceptor())
+
+        val client = builder.build()
+
+        return Retrofit.Builder()
+            .baseUrl(Constant.BASE_URL)
+            .addConverterFactory(GsonConverterFactory.create())
+            .client(client)
+            .build()
+    }
+
+    val apiService: ApiService = callApi().create(ApiService::class.java)
+}

--- a/app/src/main/java/com/sun/spoonacular/data/source/remote/api/ApiService.kt
+++ b/app/src/main/java/com/sun/spoonacular/data/source/remote/api/ApiService.kt
@@ -1,0 +1,12 @@
+package com.sun.spoonacular.data.source.remote.api
+
+import com.sun.spoonacular.data.model.RecipeResponse
+import com.sun.spoonacular.utils.Constant
+import retrofit2.Response
+import retrofit2.http.GET
+
+interface ApiService {
+
+    @GET(Constant.RANDOM)
+    suspend fun getRecipe() : Response<RecipeResponse>
+}

--- a/app/src/main/java/com/sun/spoonacular/data/source/remote/api/AuthenticationInterceptor.kt
+++ b/app/src/main/java/com/sun/spoonacular/data/source/remote/api/AuthenticationInterceptor.kt
@@ -1,0 +1,16 @@
+package com.sun.spoonacular.data.source.remote.api
+
+import com.sun.spoonacular.utils.Constant
+import okhttp3.Interceptor
+import okhttp3.Response
+
+class AuthenticationInterceptor: Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val newRequest = chain.request().newBuilder()
+            .addHeader(Constant.API_KEY, Constant.API_VALUE)
+            .addHeader(Constant.HOST_KEY, Constant.HOST_VALUE)
+            .build()
+        return chain.proceed(newRequest)
+    }
+}

--- a/app/src/main/java/com/sun/spoonacular/ui/base/MainFragment.kt
+++ b/app/src/main/java/com/sun/spoonacular/ui/base/MainFragment.kt
@@ -48,9 +48,7 @@ class MainFragment : Fragment(), BottomNavigationView.OnNavigationItemSelectedLi
     override fun onPageScrollStateChanged(state: Int) {}
 
     private fun setUpViewPager() {
-        containerViewpager.adapter = fragmentManager?.let {
-            MainMenuViewPagerAdapter(it)
-        }
+        containerViewpager.adapter = MainMenuViewPagerAdapter(childFragmentManager)
         containerViewpager.apply {
             addOnPageChangeListener(this@MainFragment)
             currentItem = MenuNumber.HOME.pageNumber

--- a/app/src/main/java/com/sun/spoonacular/ui/splash/SplashFragment.kt
+++ b/app/src/main/java/com/sun/spoonacular/ui/splash/SplashFragment.kt
@@ -4,16 +4,53 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
 import com.sun.spoonacular.R
+import com.sun.spoonacular.ui.base.MainFragment
+import com.sun.spoonacular.utils.*
+import kotlinx.android.synthetic.main.fragment_splash.*
 
 class SplashFragment : Fragment() {
+
+    private val splashViewModel by lazy {
+        ViewModelProvider(this).get(SplashViewModel::class.java)
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
         return inflater.inflate(R.layout.fragment_splash, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        registerObservers()
+    }
+
+    private fun registerObservers() {
+        splashViewModel.getRecipe().observe(viewLifecycleOwner, { userList ->
+            userList?.let { it ->
+                when (it.status) {
+                    Status.SUCCESS -> {
+                        Toast.makeText(
+                            context,
+                            it.data?.body()?.recipes?.size.toString(),
+                            Toast.LENGTH_SHORT
+                        ).show()
+                        replaceFragmentNoStack(MainFragment.newInstance(), R.id.mainContainer)
+                    }
+                    Status.ERROR -> {
+                        progressBar.visibility = View.GONE
+                        Toast.makeText(context, it.message, Toast.LENGTH_LONG).show()
+                    }
+                    Status.LOADING -> {
+                    }
+                }
+            }
+        })
     }
 
     companion object {

--- a/app/src/main/java/com/sun/spoonacular/ui/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/sun/spoonacular/ui/splash/SplashViewModel.kt
@@ -1,6 +1,21 @@
 package com.sun.spoonacular.ui.splash
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.liveData
+import com.sun.spoonacular.data.source.Repository
+import com.sun.spoonacular.utils.Resource
+import kotlinx.coroutines.Dispatchers
 
 class SplashViewModel : ViewModel() {
+
+    private val repository = Repository.getInstance()
+
+    fun getRecipe() = liveData(Dispatchers.IO) {
+        emit(Resource.loading(data = null))
+        try {
+            emit(Resource.success(data = repository.getRecipe()))
+        } catch (e: Exception) {
+            emit(Resource.error(data = null, message = e.message ?: "Error Occurred!"))
+        }
+    }
 }

--- a/app/src/main/java/com/sun/spoonacular/utils/ActivityExt.kt
+++ b/app/src/main/java/com/sun/spoonacular/utils/ActivityExt.kt
@@ -1,0 +1,8 @@
+package com.sun.spoonacular.utils
+
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+
+fun AppCompatActivity.addFragmentNoStack(fragment: Fragment, id: Int) {
+    supportFragmentManager.inTransaction { add(id, fragment) }
+}

--- a/app/src/main/java/com/sun/spoonacular/utils/Constant.kt
+++ b/app/src/main/java/com/sun/spoonacular/utils/Constant.kt
@@ -1,0 +1,12 @@
+package com.sun.spoonacular.utils
+
+import com.sun.spoonacular.BuildConfig
+
+object Constant {
+    const val BASE_URL = "https://spoonacular-recipe-food-nutrition-v1.p.rapidapi.com/recipes/"
+    const val RANDOM = "random?number=15"
+    const val API_KEY = "x-rapidapi-key"
+    const val API_VALUE = BuildConfig.API_KEY
+    const val HOST_KEY = "x-rapidapi-host"
+    const val HOST_VALUE = "spoonacular-recipe-food-nutrition-v1.p.rapidapi.com"
+}

--- a/app/src/main/java/com/sun/spoonacular/utils/FragmentExt.kt
+++ b/app/src/main/java/com/sun/spoonacular/utils/FragmentExt.kt
@@ -4,24 +4,20 @@ import android.app.Activity
 import android.content.Context
 import android.view.View
 import android.view.inputmethod.InputMethodManager
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 
-fun AppCompatActivity.addFragment(fragment: Fragment, id: Int) {
-    supportFragmentManager.inTransaction { add(id, fragment) }
-}
-
-fun AppCompatActivity.addFragmentF(fragment: Fragment,id: Int){
-    supportFragmentManager.inTransaction { add(id, fragment).addToBackStack(null) }
+fun Fragment.addFragmentNoStack(fragment: Fragment, id: Int) {
+    fragmentManager?.inTransaction { add(id, fragment) }
 }
 
 fun Fragment.addFragment(fragment: Fragment, id: Int) {
     fragmentManager?.inTransaction { add(id, fragment).addToBackStack(null) }
 }
-fun Fragment.replaceFragment(fragment: Fragment, id: Int) {
-    fragmentManager?.inTransaction { replace(id, fragment).addToBackStack(null) }
+
+fun Fragment.replaceFragmentNoStack(fragment: Fragment, id: Int) {
+    fragmentManager?.inTransaction { replace(id, fragment) }
 }
 
 inline fun FragmentManager.inTransaction(func: FragmentTransaction.() -> FragmentTransaction) {

--- a/app/src/main/java/com/sun/spoonacular/utils/Resource.kt
+++ b/app/src/main/java/com/sun/spoonacular/utils/Resource.kt
@@ -1,0 +1,19 @@
+package com.sun.spoonacular.utils
+
+import com.sun.spoonacular.utils.Status.ERROR
+import com.sun.spoonacular.utils.Status.LOADING
+import com.sun.spoonacular.utils.Status.SUCCESS
+
+data class Resource<out T>(val status: Status, val data: T?, val message: String?) {
+
+    companion object {
+        fun <T> success(data: T): Resource<T> =
+            Resource(status = SUCCESS, data = data, message = null)
+
+        fun <T> error(data: T?, message: String): Resource<T> =
+            Resource(status = ERROR, data = data, message = message)
+
+        fun <T> loading(data: T?): Resource<T> =
+            Resource(status = LOADING, data = data, message = null)
+    }
+}

--- a/app/src/main/java/com/sun/spoonacular/utils/Status.kt
+++ b/app/src/main/java/com/sun/spoonacular/utils/Status.kt
@@ -1,0 +1,7 @@
+package com.sun.spoonacular.utils
+
+enum class Status {
+    SUCCESS,
+    ERROR,
+    LOADING
+}


### PR DESCRIPTION
## Related Tickets
- [#Task 34562: Get data home page](https://edu-redmine.sun-asterisk.vn/issues/34562)
## WHAT
- Get data using retrofit okhttp coroutine
- Load data in splash creen, then send data to home fragment
## Evidence (Screenshot or Video)
Load data
![image](https://user-images.githubusercontent.com/73867223/111560612-68b60b00-87c5-11eb-91be-3bb6a4e36517.png)
Get data success => list recipe : size = 15
![image](https://user-images.githubusercontent.com/73867223/111560629-710e4600-87c5-11eb-8657-714d683286ae.png)

## Review Checklist

Category | View Point | Description | Expected Reviewer Answer | Self review | Reviewer2 (name)
--- | --- | --- | --- | --- | ---
Conventions | Does the code follow Sun* coding style and coding conventions? | https://github.com/framgia/coding-standards/tree/master/eng/android | YES |<li>- [ ] yes</li>|<li>- [ ] yes</li>  
Redmine | Does the ticket follow Sun* Redmine working process?  | https://github.com/framgia/Training-Guideline/blob/master/WorkingProcess/redmine/redmine.md| YES |<li>- [ ] yes</li>|<li>- [ ] yes</li>  
Documentation | Is there any incomplete code? If so, should it be removed or flagged with a suitable marker like ‘TODO’? |  | YES |<li>- [ ] yes</li>|<li>- [ ] yes</li>  
## Notes (Optional)
*(Impacted Areas in Application(List features, api, models or services that this PR will affect))*

*(List gem, library third party add new)*

*(Other notes)*
